### PR TITLE
Update Ubuntu version to support new RPI revisions

### DIFF
--- a/image-creation-tool/ubuntu/Makefile
+++ b/image-creation-tool/ubuntu/Makefile
@@ -3,8 +3,8 @@
 #gem install --no-document fpm
 
 URL := https://cdimage.ubuntu.com/releases/20.04.4/release/ubuntu-20.04.4-preinstalled-server-arm64+raspi.img.xz
-XZ := ubuntu-20.04.3-preinstalled-server-arm64+raspi.img.xz
-ISO := ubuntu-20.04.3-preinstalled-server-arm64+raspi.img
+XZ := ubuntu-20.04.4-preinstalled-server-arm64+raspi.img.xz
+ISO := ubuntu-20.04.4-preinstalled-server-arm64+raspi.img
 RELEASE:= 00
 DATE := $(shell date +"%y.%m")
 iso:

--- a/image-creation-tool/ubuntu/Makefile
+++ b/image-creation-tool/ubuntu/Makefile
@@ -2,7 +2,7 @@
 #apt-get install ruby ruby-dev rubygems build-essential rpm
 #gem install --no-document fpm
 
-URL := https://cdimage.ubuntu.com/releases/20.04.3/release/ubuntu-20.04.3-preinstalled-server-arm64+raspi.img.xz
+URL := https://cdimage.ubuntu.com/releases/20.04.4/release/ubuntu-20.04.4-preinstalled-server-arm64+raspi.img.xz
 XZ := ubuntu-20.04.3-preinstalled-server-arm64+raspi.img.xz
 ISO := ubuntu-20.04.3-preinstalled-server-arm64+raspi.img
 RELEASE:= 00


### PR DESCRIPTION
Fixes #26 

I'm running the new Ubuntu version on my Raspberry PI. Everything looks good:
```shell
ethereum@ethereumonarm-f9808bc20:~$ cat /proc/cpuinfo
...
Hardware	: BCM2835
Revision	: d03115
Serial		: 100000008bd5d2bb
Model		: Raspberry Pi 4 Model B Rev 1.5
ethereum@ethereumonarm-f9808bc20:~$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 20.04.4 LTS
Release:	20.04
Codename:	focal
ethereum@ethereumonarm-f9808bc20:~$ geth version
Geth
Version: 1.10.16-stable
Git Commit: 20356e57b119b4e70ce47665a71964434e15200d
Git Commit Date: 20220215
Architecture: arm64
Go Version: go1.17.5
Operating System: linux
GOPATH=
GOROOT=go