### PR TITLE
Added: `-u` unit flag to jounralctl service logging

### DIFF
--- a/docs/kiln/kiln-testnet.rst
+++ b/docs/kiln/kiln-testnet.rst
@@ -231,8 +231,8 @@ These 2 commands will start the **Execution Layer and the Consensus Layer Beacon
 You can check both client logs by running:
 
 .. prompt:: bash $
-  sudo journalctl geth-lh -f
-  sudo journalctl lh-geth-beacon -f
+  sudo journalctl -u geth-lh -f
+  sudo journalctl -u lh-geth-beacon -f
 
 .. note::
   For :guilabel:`Lighthouse` and :guilabel:`Prysm` you will need to start an additional service 


### PR DESCRIPTION
### What was wrong?
There was a missing `-u` unit flag for the journalctl service logging. 

### How was it fixed?
Added the `-u` flag to the documentation. 