### PR TITLE
Update recommended-hardware.rst for Rock 5B

### DIFF
--- a/docs/quick-guide/recommended-hardware.rst
+++ b/docs/quick-guide/recommended-hardware.rst
@@ -28,7 +28,7 @@ If you don't know what an Ethereum node is, please visit the :doc:`User Guide se
     * **Ethernet cable**
     * **Port forwarding** (see clients for further info)
     * **A case with passive heatsinkn**
-    * USB keyboard, Monitor and HDMI cable (micro-HDMI) (Optional)
+    * USB keyboard, Monitor and HDMI cable (full size) (Optional)
 
   .. tab:: Raspberry Pi 4
 


### PR DESCRIPTION
Rock 5B uses a full size HDMI cables per https://wiki.radxa.com/Rock5/5b/getting_started. 

Documentation says micro-HDMI instead this changes the documentation to indicate it's full size. I think we should mention full size rather than nothing, as most folks will expect it to be micro. 