### PR TITLE
Update mev-boost.rst

### DIFF
--- a/docs/user-guide/mev-boost.rst
+++ b/docs/user-guide/mev-boost.rst
@@ -103,11 +103,18 @@ Add the flag ``--enable-builder`` at the end of the file.
 Nimbus
 ~~~~~~
 
-Edit the Nimbus config file:
+Edit the Beacon config file:
 
 .. prompt:: bash $
 
-  sudo vim /etc/ethereum/nimbus.conf
+  sudo vim /etc/ethereum/nimbus-beacon.conf
 
-Add the flags ``--payload-builder=true --payload-builder-url=http://localhost:18550`` 
-at the end of the file.
+Add the flags ``--payload-builder=true --payload-builder-url=http://localhost:18550`` at the end of the file.
+
+Edit the Validator config file:
+
+.. prompt:: bash $
+
+  sudo vim /etc/ethereum/nimbus-validator.conf
+
+Add the flag ``--payload-builder=true`` at the end of the file.


### PR DESCRIPTION
From version 23.1.0, Nimbus upgraded to run as 2 independent processes, 1 binary for the Beacon Chain and 1 binary for the validator (so 2 different services). According to https://nimbus.guide/external-block-builder.html "External block building is must be enabled on both beacon node and validator client".