### PR TITLE
Use the correct checkpoint sync beacon endpoint (testnet)

### DIFF
--- a/fpm-package-builder/l1-clients/consensus-layer/lighthouse/sources/etc/ethereum/lighthouse-beacon-prater.conf
+++ b/fpm-package-builder/l1-clients/consensus-layer/lighthouse/sources/etc/ethereum/lighthouse-beacon-prater.conf
@@ -1,2 +1,2 @@
-ARGS="beacon --network prater --execution-endpoint http://127.0.0.1:8551 --validator-monitor-auto --execution-jwt /etc/ethereum/jwtsecret --checkpoint-sync-url https://goerli.checkpoint-sync.ethdevops.io --eth1 --http --metrics"
+ARGS="beacon --network prater --execution-endpoint http://127.0.0.1:8551 --validator-monitor-auto --execution-jwt /etc/ethereum/jwtsecret --checkpoint-sync-url https://checkpoint-sync.goerli.ethpandaops.io --eth1 --http --metrics"
     


### PR DESCRIPTION
Use `--checkpoint-sync-url=https://checkpoint-sync.goerli.ethpandaops.io` as mentioned in the docs at https://checkpoint-sync.goerli.ethpandaops.io/ .

The current value fails with:
```
CRIT Failed to start beacon node, reason: Error fetching finalized block from remote: Reqwest(reqwest::Error { kind: Request, url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("goerli.checkpoint-sync.ethdevops.io")), port: None, path: "/eth/v2/beacon/blocks/finalized", query: None, fragment: None }, source: hyper::Error(Connect, Ssl(Error { code: ErrorCode(1), cause: Some(Ssl(ErrorStack([Error { code: 337047686, library: "SSL routines", function: "tls_process_server_certificate", reason: "certificate verify failed", file: "ssl/statem/statem_clnt.c", line: 1921 }]))) }, X509VerifyResult { code: 18, error: "self signed certificate" })) }), module: lighthouse:574
```